### PR TITLE
Escape <, > and & in text supplied by the user

### DIFF
--- a/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
+++ b/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
@@ -179,16 +179,16 @@ public class PullRequestActivityListener {
 		        attachment.setColor(ColorCode.BLUE.getCode());
 		        attachment.setFallback(String.format("%s opened pull request \"%s\". <%s|(open)>",
 		                                                userName,
-		                                                event.getPullRequest().getTitle(),
+		                                                escapeUserContent(event.getPullRequest().getTitle()),
 		                                                url));
 		        attachment.setText(String.format("opened pull request <%s|#%d: %s>",
 		                                                url,
 		                                                event.getPullRequest().getId(),
-		                                                event.getPullRequest().getTitle()));
+		                                                escapeUserContent(event.getPullRequest().getTitle())));
 
 
 		        if (resolvedLevel == NotificationLevel.COMPACT) {
-		            this.addField(attachment, "Description", event.getPullRequest().getDescription());
+		            this.addField(attachment, "Description", escapeUserContent(event.getPullRequest().getDescription()));
 		        }
 
 		        if (resolvedLevel == NotificationLevel.VERBOSE) {
@@ -200,15 +200,15 @@ public class PullRequestActivityListener {
 		        attachment.setColor(ColorCode.BLUE.getCode());
 		        attachment.setFallback(String.format("%s reopened pull request \"%s\". <%s|(open)>",
 		                                                userName,
-		                                                event.getPullRequest().getTitle(),
+		                                                escapeUserContent(event.getPullRequest().getTitle()),
 		                                                url));
 		        attachment.setText(String.format("reopened pull request <%s|#%d: %s>",
 		                                                url,
 		                                                event.getPullRequest().getId(),
-		                                                event.getPullRequest().getTitle()));
+		                                                escapeUserContent(event.getPullRequest().getTitle())));
 
 		        if (resolvedLevel == NotificationLevel.COMPACT) {
-		            this.addField(attachment, "Description", event.getPullRequest().getDescription());
+		            this.addField(attachment, "Description", escapeUserContent(event.getPullRequest().getDescription()));
 		        }
 		        if (resolvedLevel == NotificationLevel.VERBOSE) {
 		            this.addReviewers(attachment, event.getPullRequest().getReviewers());
@@ -219,15 +219,15 @@ public class PullRequestActivityListener {
 		        attachment.setColor(ColorCode.PURPLE.getCode());
 		        attachment.setFallback(String.format("%s updated pull request \"%s\". <%s|(open)>",
 		                                                userName,
-		                                                event.getPullRequest().getTitle(),
+		                                                escapeUserContent(event.getPullRequest().getTitle()),
 		                                                url));
 		        attachment.setText(String.format("updated pull request <%s|#%d: %s>",
 		                                                url,
 		                                                event.getPullRequest().getId(),
-		                                                event.getPullRequest().getTitle()));
+		                                                escapeUserContent(event.getPullRequest().getTitle())));
 
 		        if (resolvedLevel == NotificationLevel.COMPACT) {
-		            this.addField(attachment, "Description", event.getPullRequest().getDescription());
+		            this.addField(attachment, "Description", escapeUserContent(event.getPullRequest().getDescription()));
 		        }
 		        if (resolvedLevel == NotificationLevel.VERBOSE) {
 		            this.addReviewers(attachment, event.getPullRequest().getReviewers());
@@ -238,55 +238,55 @@ public class PullRequestActivityListener {
 		        attachment.setColor(ColorCode.GREEN.getCode());
 		        attachment.setFallback(String.format("%s approved pull request \"%s\". <%s|(open)>",
 		                                                userName,
-		                                                event.getPullRequest().getTitle(),
+		                                                escapeUserContent(event.getPullRequest().getTitle()),
 		                                                url));
 		        attachment.setText(String.format("approved pull request <%s|#%d: %s>",
 		                                                url,
 		                                                event.getPullRequest().getId(),
-		                                                event.getPullRequest().getTitle()));
+		                                                escapeUserContent(event.getPullRequest().getTitle())));
 		        break;
 
 		    case UNAPPROVED:
 		        attachment.setColor(ColorCode.RED.getCode());
 		        attachment.setFallback(String.format("%s unapproved pull request \"%s\". <%s|(open)>",
 		                                                userName,
-		                                                event.getPullRequest().getTitle(),
+		                                                escapeUserContent(event.getPullRequest().getTitle()),
 		                                                url));
 		        attachment.setText(String.format("unapproved pull request <%s|#%d: %s>",
 		                                                url,
 		                                                event.getPullRequest().getId(),
-		                                                event.getPullRequest().getTitle()));
+		                                                escapeUserContent(event.getPullRequest().getTitle())));
 		        break;
 
 		    case DECLINED:
 		        attachment.setColor(ColorCode.DARK_RED.getCode());
 		        attachment.setFallback(String.format("%s declined pull request \"%s\". <%s|(open)>",
 		                                                userName,
-		                                                event.getPullRequest().getTitle(),
+		                                                escapeUserContent(event.getPullRequest().getTitle()),
 		                                                url));
 		        attachment.setText(String.format("declined pull request <%s|#%d: %s>",
 		                                                url,
 		                                                event.getPullRequest().getId(),
-		                                                event.getPullRequest().getTitle()));
+		                                                escapeUserContent(event.getPullRequest().getTitle())));
 		        break;
 
 		    case MERGED:
 		        attachment.setColor(ColorCode.DARK_GREEN.getCode());
 		        attachment.setFallback(String.format("%s merged pull request \"%s\". <%s|(open)>",
 		                                                userName,
-		                                                event.getPullRequest().getTitle(),
+		                                                escapeUserContent(event.getPullRequest().getTitle()),
 		                                                url));
 		        attachment.setText(String.format("merged pull request <%s|#%d: %s>",
 		                                                url,
 		                                                event.getPullRequest().getId(),
-		                                                event.getPullRequest().getTitle()));
+		                                                escapeUserContent(event.getPullRequest().getTitle())));
 		        break;
 
 		    case RESCOPED:
 		        attachment.setColor(ColorCode.PURPLE.getCode());
 		        attachment.setFallback(String.format("%s rescoped on pull request \"%s\". <%s|(open)>",
 		                                                userName,
-		                                                event.getPullRequest().getTitle(),
+		                                                escapeUserContent(event.getPullRequest().getTitle()),
 		                                                url));
 		        attachment.setText(String.format("rescoped on pull request <%s|#%d: %s>",
 		                                                url,
@@ -303,20 +303,20 @@ public class PullRequestActivityListener {
 		        attachment.setColor(ColorCode.PALE_BLUE.getCode());
 		        attachment.setFallback(String.format("%s commented on pull request \"%s\". <%s|(open)>",
 		                                                userName,
-		                                                event.getPullRequest().getTitle(),
+		                                                escapeUserContent(event.getPullRequest().getTitle()),
 		                                                commentUrl));
 		        if (resolvedLevel == NotificationLevel.MINIMAL) {
 		            attachment.setText(String.format("commented on pull request <%s|#%d: %s>",
 		                    commentUrl,
 		                    event.getPullRequest().getId(),
-		                    event.getPullRequest().getTitle()));
+		                    escapeUserContent(event.getPullRequest().getTitle())));
 		        }
 		        if (resolvedLevel == NotificationLevel.COMPACT || resolvedLevel == NotificationLevel.VERBOSE) {
 		            attachment.setText(String.format("commented on pull request <%s|#%d: %s>\n%s",
 		                    commentUrl,
 		                    event.getPullRequest().getId(),
-		                    event.getPullRequest().getTitle(),
-		                    ((PullRequestCommentActivityEvent) event).getActivity().getComment().getText()));
+		                    escapeUserContent(event.getPullRequest().getTitle()),
+		                    escapeUserContent(((PullRequestCommentActivityEvent) event).getActivity().getComment().getText())));
 		        }
 		        break;
             
@@ -355,6 +355,13 @@ public class PullRequestActivityListener {
 
 		payload.addAttachment(attachment);
 		return payload;
+	}
+
+	private String escapeUserContent(String content) {
+		/* per https://api.slack.com/docs/message-formatting#how_to_escape_characters */
+		return content.replace("&", "&amp;")
+		              .replace("<", "&lt;")
+		              .replace(">", "&gt;");
 	}
 
     private void addField(SlackAttachment attachment, String title, String message) {


### PR DESCRIPTION
This makes it so that links in slack get displayed properly most of the time.

We've had the issue that when a title of a PR included `>`, the link in the message posted to slack would be send as `<http://example.com|The <PR> title>` which would be rendered by slack as something similiar to this: [The <PR](http://example.com) title>

Why most of the time? Because a title mentioning a slack user in pointy brackets is still breaking this:

* Title: `PR for <@userhandle>, plz review asap`
* Encoded: `PR for &lt;@userhandle&gt;, plz review asap`
* Rendered: [PR for <@USERID](http://example.com/PR_URL), plz reviwe asap
* Expected: [PR for `@userhandle`, plz review asap](http://example.com/PR_URL)